### PR TITLE
bugfix: "panic: assignment to entry in nil map"

### DIFF
--- a/function.go
+++ b/function.go
@@ -12,7 +12,7 @@ import (
 func LoadFunctions() ( err error ) {
 	successfulCount := len( Cfg.FunctionFiles )
 	errors := make( []string, 0 )
-	var bypass map[string]bool
+	bypass := make(map[string]bool)
 
 	files, err := ResolveDependencies( Cfg.FunctionFiles, Cfg.SqlDirPath + "functions" )
 	if err != nil { return err }

--- a/trigger.go
+++ b/trigger.go
@@ -12,7 +12,7 @@ import (
 func LoadTriggers() ( err error ) {
 	successfulCount := len( Cfg.TriggerFiles )
 	errors := make( []string, 0 )
-	var bypass map[string]bool
+	bypass := make(map[string]bool)
 
 	files, err := ResolveDependencies( Cfg.TriggerFiles, Cfg.SqlDirPath + "triggers" )
 	if err != nil { return err }
@@ -101,4 +101,3 @@ func ( trigger *Trigger ) Drop() ( err error ) {
 func ( trigger *Trigger ) Create() ( err error ) {
 	return trigger.CodeUnit.Create( trigger.Definition )
 }
-

--- a/type.go
+++ b/type.go
@@ -12,7 +12,7 @@ import (
 func LoadTypes() ( err error ) {
 	successfulCount := len( Cfg.TypeFiles )
 	errors := make( []string, 0 )
-	var bypass map[string]bool
+	bypass := make(map[string]bool)
 
 	files, err := ResolveDependencies( Cfg.TypeFiles, Cfg.SqlDirPath + "types" )
 	if err != nil { return err }

--- a/view.go
+++ b/view.go
@@ -12,7 +12,7 @@ import (
 func LoadViews() ( err error ) {
 	successfulCount := len( Cfg.ViewFiles )
 	errors := make( []string, 0 )
-	var bypass map[string]bool
+	bypass := make(map[string]bool)
 
 	files, err := ResolveDependencies( Cfg.ViewFiles, Cfg.SqlDirPath + "views" )
 	if err != nil { return err }


### PR DESCRIPTION
I'm not a Go developer, but I found a nil map assignment.

I was trying to connect to the database without `sslmode=disable` parameter and received the following output: 

```
panic: assignment to entry in nil map

goroutine 1 [running]:
panic(0x204240, 0xc4200130a0)
	/usr/local/Cellar/go/1.7.3/libexec/src/runtime/panic.go:500 +0x1a1
main.LoadFunctions(0x0, 0x0)
	/Users/leobessa/go/src/github.com/oelmekki/pgrebase/function.go:31 +0x403
main.Process(0x20b4a0, 0x0)
	/Users/leobessa/go/src/github.com/oelmekki/pgrebase/main.go:84 +0x50
main.main()
	/Users/leobessa/go/src/github.com/oelmekki/pgrebase/main.go:134 +0x38
Loaded 0 types
Loaded 0 views
```

And now, after this change:

```
Loaded 0 types
Loaded 0 views
Loaded 0 functions - 1 with error
  error while loading sql/functions/base_shifts.sql
  pq: SSL is not enabled on the server

Error:   error while loading sql/functions/base_shifts.sql
  pq: SSL is not enabled on the server
```

Maybe you should also consider adding a note about `sslmode=disable` on README.