### PR TITLE
FIX functions default parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func CheckSanity() {
  */
 func Usage() {
 	usage := `
-PgRebase-1.1.0
+PgRebase-1.1.1+
 
 USAGE:
 	DATABASE_URL=url pgrebase [-w] <sql_directory>


### PR DESCRIPTION
`DROP FUNCTION` does not allow to provide default values in signature,
making a direct mirroring of `CREATE FUNCTION` signature fails.

Parsed signature to be sure to remove default before dropping function.